### PR TITLE
Bind addr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+varnish-purge-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM kiasaki/alpine-golang
+
+WORKDIR /gopath/src/app
+ADD . /gopath/src/app/
+RUN go get app
+
+CMD []
+ENTRYPOINT ["/gopath/bin/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM kiasaki/alpine-golang
-
-WORKDIR /gopath/src/app
-ADD varnish-purge-proxy.go /gopath/src/app/varnish-purge-proxy.go
-RUN go get app
-
-CMD []
-ENTRYPOINT ["/gopath/bin/app"]
+FROM scratch
+EXPOSE 8000
+COPY varnish-purge-proxy /
+ENTRYPOINT ["/varnish-purge-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+FROM alpine:3.2
+RUN apk --update add ca-certificates curl
 EXPOSE 8000
-COPY varnish-purge-proxy /
-ENTRYPOINT ["/varnish-purge-proxy"]
+COPY varnish-purge-proxy /usr/bin/
+ENTRYPOINT ["/usr/bin/varnish-purge-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM kiasaki/alpine-golang
 
 WORKDIR /gopath/src/app
-ADD . /gopath/src/app/
+ADD varnish-purge-proxy.go /gopath/src/app/varnish-purge-proxy.go
 RUN go get app
 
 CMD []

--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ Building
 Build a binary by running:
 
 `go build varnish-purge-proxy.go`
+
+
+Running in Docker
+----------------
+
+`docker build -t varnish-proxy .`
+`docker run -e AWS_ACCESS_KEY=key-id -e AWS_ACCESS_SECRET=secret -p 8000:8000 varnish-proxy Service:varnish Environment:test`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Build a binary by running:
 `go build varnish-purge-proxy.go`
 
 
+Build adocker image container by running:
+
+`./make-container-image.sh [name of image]`
+
 Running in Docker
 ----------------
 

--- a/make-docker-image.sh
+++ b/make-docker-image.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
+
 docker run --rm \
   -v "$(pwd):/src" \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  centurylink/golang-builder docker-registry.made.com/varnish-purge-proxy:3
+  centurylink/golang-builder $1

--- a/make-docker-image.sh
+++ b/make-docker-image.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+docker run --rm \
+  -v "$(pwd):/src" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  centurylink/golang-builder docker-registry.made.com/varnish-purge-proxy:3

--- a/varnish-purge-proxy.go
+++ b/varnish-purge-proxy.go
@@ -1,4 +1,4 @@
-package main
+package main // import "github.com/madedotcom/varnish-purge-proxy"
 
 /*
  * varnish-purge-proxy
@@ -35,6 +35,7 @@ import (
 var (
 	port            = kingpin.Flag("port", "Port to listen on.").Default("8000").Int()
 	cache           = kingpin.Flag("cache", "Time in seconds to cache instance IP lookup.").Default("60").Int()
+    host            = kingpin.Flag("host", "host address to listen on, defaults to 127.0.0.1").Default("127.0.0.1").String()
 	tags            = kingpin.Arg("tag", "Key:value pair of tags to match EC2 instances.").Strings()
 	region          aws.Region
 	ResetAfter      time.Time
@@ -77,7 +78,7 @@ func main() {
 	}
 	ec2region := ec2.New(auth, region)
 
-	go serveHTTP(*port, ec2region)
+	go serveHTTP(*port, *host, ec2region)
 
 	select {}
 }
@@ -119,7 +120,7 @@ func newTimeoutClient(args ...interface{}) *http.Client {
 	}
 }
 
-func serveHTTP(port int, ec2region *ec2.EC2) {
+func serveHTTP(port int, host string, ec2region *ec2.EC2) {
 	client := newTimeoutClient()
 
 	mux := http.NewServeMux()
@@ -127,7 +128,7 @@ func serveHTTP(port int, ec2region *ec2.EC2) {
 		requestHandler(w, r, client, ec2region)
 	})
 
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := fmt.Sprintf("%v:%d", host, port)
 	server := &http.Server{
 		Addr:           addr,
 		Handler:        mux,

--- a/varnish-purge-proxy.go
+++ b/varnish-purge-proxy.go
@@ -35,7 +35,7 @@ import (
 var (
 	port            = kingpin.Flag("port", "Port to listen on.").Default("8000").Int()
 	cache           = kingpin.Flag("cache", "Time in seconds to cache instance IP lookup.").Default("60").Int()
-    host            = kingpin.Flag("host", "host address to listen on, defaults to 127.0.0.1").Default("127.0.0.1").String()
+    listen          = kingpin.Flag("listen", "host address to listen on, defaults to 127.0.0.1").Default("127.0.0.1").String()
 	tags            = kingpin.Arg("tag", "Key:value pair of tags to match EC2 instances.").Strings()
 	region          aws.Region
 	ResetAfter      time.Time
@@ -78,7 +78,7 @@ func main() {
 	}
 	ec2region := ec2.New(auth, region)
 
-	go serveHTTP(*port, *host, ec2region)
+	go serveHTTP(*port, *listen, ec2region)
 
 	select {}
 }


### PR DESCRIPTION
Leave this open for now, and I'll try and get some better looking docs later today.

You can build yourself a nice lean container by running

`make-docker-image.sh bashton/varnish-purge-proxy:1`

The docker image is based on Alpine:3.2 and includes curl and ca-certificates. If you need to poke around inside it when it's running, just do `docker exec -it [my-container] sh`