### PR TITLE
Permit use with Magento 2

### DIFF
--- a/varnish-purge-proxy.go
+++ b/varnish-purge-proxy.go
@@ -130,7 +130,7 @@ func serveHTTP(port int, host string, service providers.Service) {
 
 func requestHandler(w http.ResponseWriter, r *http.Request, client *http.Client, service providers.Service) {
 	// check that request is PURGE and has X-Purge-Regex header set
-	if _, exists := r.Header["X-Purge-Regex"]; !exists || r.Method != "PURGE" {
+	if valid, _ := validateRequest(r); !valid {
 		if *debug {
 			log.Printf("Error invalid request: %s, %s\n", r.Header, r.Method)
 		}
@@ -180,6 +180,18 @@ func requestHandler(w http.ResponseWriter, r *http.Request, client *http.Client,
 	default:
 		return
 	}
+}
+
+func validateRequest(r *http.Request) (bool, string) {
+	// check that request is PURGE
+	if r.Method != "PURGE" {
+		return false, "Invalid method: " + r.Method
+	}
+	// check that request has the X-Purge-Regex header set
+	if _, exists := r.Header["X-Purge-Regex"]; !exists {
+		return false, "Missing required header"
+	}
+	return true, "Valid"
 }
 
 func copyRequest(src *http.Request) (*http.Request, error) {

--- a/varnish-purge-proxy.go
+++ b/varnish-purge-proxy.go
@@ -42,6 +42,7 @@ var (
 	destport = app.Flag("destport", "The destination port of the varnish server to target.").Default("80").Int()
 	listen   = app.Flag("listen", "Host address to listen on, defaults to 127.0.0.1").Default("127.0.0.1").String()
 	port     = app.Flag("port", "Port to listen on.").Default("8000").Int()
+	header   = app.Flag("header", "HTTP header to require").Default("X-Purge-Regex").String()
 
 	// AWS service args
 	awsService = app.Command("aws", "Use AWS service.")
@@ -188,8 +189,8 @@ func validateRequest(r *http.Request) (bool, string) {
 		return false, "Invalid method: " + r.Method
 	}
 	// check that request has the X-Purge-Regex header set
-	if _, exists := r.Header["X-Purge-Regex"]; !exists {
-		return false, "Missing required header"
+	if _, exists := r.Header[*header]; !exists {
+		return false, "Missing required header: " + *header
 	}
 	return true, "Valid"
 }

--- a/varnish-purge-proxy_test.go
+++ b/varnish-purge-proxy_test.go
@@ -77,3 +77,12 @@ func TestForwardRequest(t *testing.T) {
 	}
 
 }
+
+func TestCopyRequest(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("X-Foo", "")
+
+	dup, _ := copyRequest(req)
+	expect(t, "host is copied", dup.Host, req.Host)
+	expect(t, "header is copied", dup.Header.Get("X-Foo"), req.Header.Get("X-Foo"))
+}

--- a/varnish-purge-proxy_test.go
+++ b/varnish-purge-proxy_test.go
@@ -86,3 +86,29 @@ func TestCopyRequest(t *testing.T) {
 	expect(t, "host is copied", dup.Host, req.Host)
 	expect(t, "header is copied", dup.Header.Get("X-Foo"), req.Header.Get("X-Foo"))
 }
+
+func TestValidateRequest(t *testing.T) {
+	cases := map[string]struct {
+		method   string
+		header   string
+		expected bool
+		message  string
+	}{
+		"badmethod": {"GET", "", false, "Invalid method: GET"},
+		"noheader":  {"PURGE", "", false, "Missing required header"},
+		"good":      {"PURGE", "X-Purge-Regex", true, "Valid"},
+	}
+
+	for k, tc := range cases {
+		req, err := http.NewRequest(tc.method, "http://example.com/", nil)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if tc.header != "" {
+			req.Header.Set(tc.header, "foo")
+		}
+		valid, msg := validateRequest(req)
+		expect(t, k, valid, tc.expected)
+		expect(t, k, msg, tc.message)
+	}
+}

--- a/varnish-purge-proxy_test.go
+++ b/varnish-purge-proxy_test.go
@@ -94,24 +94,21 @@ func TestValidateRequestBadMethod(t *testing.T) {
 }
 
 func TestValidateRequestMissingHeader(t *testing.T) {
-	*header = "X-Purge-Regex"
 	req, _ := http.NewRequest("PURGE", "http://example.com/", nil)
 	_, msg := validateRequest(req)
-	expect(t, "validateMissingHeader", msg, "Missing required header: X-Purge-Regex")
+	expect(t, "validateMissingHeader", msg, "Request contains no purge headers")
 }
 
-func TestValidateRequestCorrect(t *testing.T) {
-	*header = "X-Purge-Regex"
+func TestValidateRequestCorrectPhoenix(t *testing.T) {
 	req, _ := http.NewRequest("PURGE", "http://example.com/", nil)
-	req.Header.Set(*header, "foo")
+	req.Header.Set("X-Purge-Regex", "foo")
 	valid, _ := validateRequest(req)
 	expect(t, "validateDefaultHeader", valid, true)
 }
 
-func TestValidateRequestMagento2(t *testing.T) {
-	*header = "X-Magento-Tags-Pattern"
+func TestValidateRequestCorrectMagento2(t *testing.T) {
 	req, _ := http.NewRequest("PURGE", "http://example.com/", nil)
-	req.Header.Set(*header, "foo")
+	req.Header.Set("X-Magento-Tags-Pattern", "foo")
 	valid, _ := validateRequest(req)
 	expect(t, "validateCustomHeader", valid, true)
 }


### PR DESCRIPTION
When attempting to use varnish-purge-proxy with Magento 2, I found that VPP checks for the existence of a specific header which Magento 2 does not send.

The purpose of this patch is to change the request validation such that the presence of either HTTP header is sufficient.  To be honest, I'm not really sure why this check exists (ie, why the proxy is not prepared to forward _any_ PURGE request).

Please note: this is the first golang I've written, so it may not be idiomatic but it hopefully is correct (it seems to work).